### PR TITLE
use the created_at header to get the versions age

### DIFF
--- a/lib/compact_index.rb
+++ b/lib/compact_index.rb
@@ -4,6 +4,7 @@ require "compact_index/dependency"
 
 require "compact_index/version"
 require "compact_index/versions_file"
+require "compact_index/ext/date"
 
 module CompactIndex
   def self.names(gem_names)

--- a/lib/compact_index/ext/date.rb
+++ b/lib/compact_index/ext/date.rb
@@ -1,0 +1,8 @@
+require "date"
+
+# Ruby 1.8.7 makes Time#to_datetime private, but we need it
+unless Time.public_instance_methods.include? :to_datetime
+  class Time
+    public :to_datetime
+  end
+end

--- a/lib/compact_index/versions_file.rb
+++ b/lib/compact_index/versions_file.rb
@@ -34,7 +34,7 @@ class CompactIndex::VersionsFile
 
 
   def create(gems)
-    content = "created_at: #{Time.now.iso8601}"
+    content = "\Acreated_at: #{Time.now.iso8601}"
     content << "\n---\n"
     content << parse_gems_for_create(gems)
 

--- a/lib/compact_index/versions_file.rb
+++ b/lib/compact_index/versions_file.rb
@@ -18,11 +18,7 @@ class CompactIndex::VersionsFile
   end
 
   def updated_at
-    if File.exists? @path
-      DateTime.parse(File.mtime(@path).to_s)
-    else
-      Time.at(0)
-    end
+    created_at_header(@path) || Time.at(0).to_datetime
   end
 
   def update_with(gems)
@@ -101,4 +97,19 @@ class CompactIndex::VersionsFile
       gem[:versions].first[:checksum] = info_checksum
     end
   end
+
+  def created_at_header(path)
+    return unless File.exists? path
+
+    File.open(path) do |file|
+      file.each_line do |line|
+        if line.match(/created_at: (.*)\n|---\n/)
+          return match[1] && DateTime.parse(match[1])
+        end
+      end
+    end
+
+    nil
+  end
+
 end

--- a/spec/versions_file_spec.rb
+++ b/spec/versions_file_spec.rb
@@ -45,13 +45,13 @@ describe CompactIndex::VersionsFile do
         end
 
         it "add the date on top" do
-          date_regexp = /^created_at: (.*?)\n/
+          date_regexp = /\Acreated_at: (.*?)\n/
           versions_file.update_with(gems)
-          expect(
-            file.open.read.match(date_regexp)[0]
-          ).to match(
-            /(\d{4})-(\d{2})-(\d{2})T(\d{2})\:(\d{2})\:(\d{2})[+-](\d{2})\:(\d{2})/
-          )
+          file.open.read.match(date_regexp) do |m|
+            expect(m.first).to match(
+              /(\d{4})-(\d{2})-(\d{2})T(\d{2})\:(\d{2})\:(\d{2})[+-](\d{2})\:(\d{2})/
+            )
+          end
         end
 
         it "order gems by name" do

--- a/spec/versions_file_spec.rb
+++ b/spec/versions_file_spec.rb
@@ -82,7 +82,7 @@ describe CompactIndex::VersionsFile do
       end
 
       describe "when file exists" do
-        before(:each) { versions_file.send('create',gems) }
+        before(:each) { versions_file.send('create', gems) }
 
         it "add a gem" do
           gems = [CompactIndex::Gem.new('new-gem', [build_version])]
@@ -102,12 +102,20 @@ describe CompactIndex::VersionsFile do
   end
 
   describe "#updated_at" do
-    it "is a date time" do
-      expect(versions_file.updated_at).to be_kind_of(DateTime)
+    it "is epoch start when file does not exist" do
+      expect(CompactIndex::VersionsFile.new("/tmp/doesntexist").updated_at).to eq(Time.at(0).to_datetime)
     end
-    it "uses File#mtime" do
-      expect(File).to receive('mtime') { DateTime.now }
-      versions_file.updated_at
+
+    it "is epoch when created_at header does not exist" do
+      expect(versions_file.updated_at).to eq(Time.at(0).to_datetime)
+    end
+
+    it "is the created_at time when the header exists" do
+      Tempfile.new("created_at_versions") do |tmp|
+        tmp.write("created_at: 2015-08-23T17:22:53-07:00\n---\ngem2 1.0.1\n")
+        file = CompactIndex::VersionsFile.new(tmp.path).updated_at
+        expect(file.updated_at).to eq(DateTime.parse("2015-08-23T17:22:53-07:00"))
+      end
     end
   end
 


### PR DESCRIPTION
Hopefully this will fix the versions file checksums being bad? It seems like many `versions` table rows aren't being selected due to the mtime of the pre-calculated `versions.list` file, which is updated on any new git checkout etc.

/cc @segiddins