### PR TITLE
Fix a RuboCop error and offenses

### DIFF
--- a/.rubocop-bundler.yml
+++ b/.rubocop-bundler.yml
@@ -14,7 +14,7 @@ Lint/AssignmentInCondition:
   Enabled: false
 
 Lint/EndAlignment:
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 Lint/UnusedMethodArgument:
   Enabled: false

--- a/.rubocop-bundler.yml
+++ b/.rubocop-bundler.yml
@@ -2,6 +2,7 @@ inherit_from:
   - .rubocop_todo.yml
 
 AllCops:
+  TargetRubyVersion: 1.9
   Exclude:
     - tmp/**/*
     - lib/bundler/vendor/**/*
@@ -15,6 +16,7 @@ Lint/AssignmentInCondition:
 
 Lint/EndAlignment:
   EnforcedStyleAlignWith: variable
+  AutoCorrect: true
 
 Lint/UnusedMethodArgument:
   Enabled: false
@@ -24,11 +26,26 @@ Lint/UnusedMethodArgument:
 Style/AccessModifierIndentation:
   EnforcedStyle: outdent
 
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+
 Style/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
+
+Style/MultilineBlockChain:
+  Enabled: false
+
 Style/MultilineOperationIndentation:
   EnforcedStyle: indented
+
+Style/PerlBackrefs:
+  Enabled: false
+
+Style/SingleLineBlockParams:
+  Enabled: false
 
 Style/SpaceInsideBlockBraces:
   SpaceBeforeBlockParameters: false
@@ -45,6 +62,18 @@ Style/StringLiterals:
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
+
+# Having these make it easier to *not* forget to add one when adding a new
+# value and you can simply copy the previous line.
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingUnderscoreVariable:
+  Enabled: false
+
+# `String.new` is preferred style with enabled frozen string literal
+Style/EmptyLiteral:
+  Enabled: false
 
 # 1.8.7 support
 
@@ -63,14 +92,15 @@ Style/EachWithObject:
 Style/SpecialGlobalVars:
   Enabled: false
 
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Performance/FlatMap:
+  Enabled: false
+
 # Metrics
 
 # We've chosen to use Rubocop only for style, and not for complexity or quality checks.
-Metrics/BlockLength:
-  Exclude:
-    - "db/migrations/*.rb"
-    - "spec/**/*.rb"
-
 Metrics/ClassLength:
   Enabled: false
 
@@ -89,5 +119,10 @@ Metrics/AbcSize:
 Metrics/CyclomaticComplexity:
   Enabled: false
 
+Metrics/ParameterLists:
+  Enabled: false
+
+# It will be obvious which code is complex, Rubocop should only lint simple
+# rules for us.
 Metrics/PerceivedComplexity:
   Enabled: false

--- a/.rubocop-bundler.yml
+++ b/.rubocop-bundler.yml
@@ -66,6 +66,11 @@ Style/SpecialGlobalVars:
 # Metrics
 
 # We've chosen to use Rubocop only for style, and not for complexity or quality checks.
+Metrics/BlockLength:
+  Exclude:
+    - "db/migrations/*.rb"
+    - "spec/**/*.rb"
+
 Metrics/ClassLength:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,9 @@
 inherit_from: .rubocop-bundler.yml
 
+Metrics/BlockLength:
+  Exclude:
+    - "db/migrations/*.rb"
+    - "spec/**/*.rb"
+
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
+
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in compact_index.gemspec
 gemspec
 
 group :documentation do
-  gem "yard", "~> 0.8"
   gem "redcarpet", "~> 2.3"
+  gem "yard", "~> 0.8"
 end
 
 group :development do

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "bundler/gem_tasks"
 
 begin
@@ -6,7 +7,7 @@ begin
 
   desc "Run specs"
   RSpec::Core::RakeTask.new(:spec) do |t|
-    t.rspec_opts = %w(--color)
+    t.rspec_opts = %w[--color]
   end
 
   begin
@@ -16,7 +17,7 @@ begin
     task :rubocop
   end
 
-  task :default => [:rubocop, :spec]
+  task :default => %i[rubocop spec]
 rescue LoadError => e
   # rspec won't exist on production
   nil

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ begin
     task :rubocop
   end
 
-  task :default => %i[rubocop spec]
+  task :default => [:rubocop, :spec]
 rescue LoadError => e
   # rspec won't exist on production
   nil

--- a/compact_index.gemspec
+++ b/compact_index.gemspec
@@ -1,5 +1,6 @@
 # coding: utf-8
 # frozen_string_literal: true
+
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "compact_index/version"

--- a/db/migrations/01_rubygems_org_schema_dump.rb
+++ b/db/migrations/01_rubygems_org_schema_dump.rb
@@ -69,7 +69,7 @@ Sequel.migration do
       index [:position], :name => :index_versions_on_position
       index [:prerelease], :name => :index_versions_on_prerelease
       index [:rubygem_id], :name => :index_versions_on_rubygem_id
-      index %i[rubygem_id number platform],
+      index [:rubygem_id, :number, :platform],
         :name => :index_versions_on_rubygem_id_and_number_and_platform,
         :unique => true
     end

--- a/db/migrations/01_rubygems_org_schema_dump.rb
+++ b/db/migrations/01_rubygems_org_schema_dump.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Sequel.migration do
   change do
     create_table(:dependencies, :ignore_index_errors => true) do
@@ -68,7 +69,7 @@ Sequel.migration do
       index [:position], :name => :index_versions_on_position
       index [:prerelease], :name => :index_versions_on_prerelease
       index [:rubygem_id], :name => :index_versions_on_rubygem_id
-      index [:rubygem_id, :number, :platform],
+      index %i[rubygem_id number platform],
         :name => :index_versions_on_rubygem_id_and_number_and_platform,
         :unique => true
     end

--- a/db/migrations/02_prune.rb
+++ b/db/migrations/02_prune.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Sequel.migration do
   up do
     drop_table :linksets

--- a/db/migrations/03_add_ruby_and_rubygems_requirements.rb
+++ b/db/migrations/03_add_ruby_and_rubygems_requirements.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Sequel.migration do
   up do
     alter_table :versions do

--- a/db/migrations/04_add_deps_md5_to_rubygems.rb
+++ b/db/migrations/04_add_deps_md5_to_rubygems.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Sequel.migration do
   change do
     alter_table :rubygems do

--- a/db/migrations/05_create_checksums.rb
+++ b/db/migrations/05_create_checksums.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Sequel.migration do
   change do
     create_table :checksums do

--- a/db/migrations/06_add_created_at_to_versions.rb
+++ b/db/migrations/06_add_created_at_to_versions.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Sequel.migration do
   change do
     alter_table :versions do

--- a/db/migrations/07_add_checksum_to_versions.rb
+++ b/db/migrations/07_add_checksum_to_versions.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Sequel.migration do
   change do
     alter_table :versions do

--- a/lib/compact_index.rb
+++ b/lib/compact_index.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "compact_index/gem"
 require "compact_index/gem_version"
 require "compact_index/dependency"

--- a/lib/compact_index/dependency.rb
+++ b/lib/compact_index/dependency.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module CompactIndex
   Dependency = Struct.new(:gem, :version, :platform, :checksum) do
     def version_and_platform

--- a/lib/compact_index/ext/date.rb
+++ b/lib/compact_index/ext/date.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "date"
 
 # Ruby 1.8.7 makes Time#to_datetime private, but we need it

--- a/lib/compact_index/gem.rb
+++ b/lib/compact_index/gem.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module CompactIndex
   Gem = Struct.new(:name, :versions) do
     def <=>(other)

--- a/lib/compact_index/gem_version.rb
+++ b/lib/compact_index/gem_version.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module CompactIndex
+  # rubocop:disable Metrics/BlockLength
   GemVersion = Struct.new(:number, :platform, :checksum, :info_checksum,
     :dependencies, :ruby_version, :rubygems_version) do
     def number_and_platform

--- a/lib/compact_index/gem_version.rb
+++ b/lib/compact_index/gem_version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module CompactIndex
   GemVersion = Struct.new(:number, :platform, :checksum, :info_checksum,
     :dependencies, :ruby_version, :rubygems_version) do

--- a/lib/compact_index/version.rb
+++ b/lib/compact_index/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module CompactIndex
   VERSION = "0.11.0".freeze
 end

--- a/lib/compact_index/versions_file.rb
+++ b/lib/compact_index/versions_file.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "time"
 require "date"
 require "digest"

--- a/spec/compact_index_spec.rb
+++ b/spec/compact_index_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "tempfile"
 require "spec_helper"
 require "support/versions"
@@ -16,7 +17,7 @@ describe CompactIndex do
       end
     end
     context "when receive gem names" do
-      let(:gem_names) { %w(gem-1 gem_2) }
+      let(:gem_names) { %w[gem-1 gem_2] }
       it "returns the gem list" do
         expect(CompactIndex.names(gem_names)).to eq "---\ngem-1\ngem_2\n"
       end

--- a/spec/compact_index_spec.rb
+++ b/spec/compact_index_spec.rb
@@ -48,14 +48,14 @@ describe CompactIndex do
       yesterday = Time.at(Time.now.to_i - 86_400)
       param = [
         build_version(:number => "1.0.1", :checksum => "abc1"),
-        build_version(:number => "1.0.2", :checksum => "abc2")
+        build_version(:number => "1.0.2", :checksum => "abc2"),
       ]
       expect(CompactIndex.info(param)).to eq("---\n1.0.1 |checksum:abc1\n1.0.2 |checksum:abc2\n")
     end
 
     it "one dependency" do
       param = [build_version(:number => "1.0.1", :dependencies => [
-                               CompactIndex::Dependency.new("foo", "=1.0.1", "ruby", "abc123")
+                               CompactIndex::Dependency.new("foo", "=1.0.1", "ruby", "abc123"),
                              ])]
       expect(CompactIndex.info(param)).to eq("---\n1.0.1 foo:=1.0.1|checksum:sum+test_gem+1.0.1\n")
     end
@@ -63,21 +63,21 @@ describe CompactIndex do
     it "multiple dependencies" do
       param = [build_version(:number => "1.0.1", :dependencies => [
                                CompactIndex::Dependency.new("foo1", "=1.0.1", "ruby", "abc123"),
-                               CompactIndex::Dependency.new("foo2", "<2.0", "ruby", "abc123")
+                               CompactIndex::Dependency.new("foo2", "<2.0", "ruby", "abc123"),
                              ])]
       expect(CompactIndex.info(param)).to eq("---\n1.0.1 foo1:=1.0.1,foo2:<2.0|checksum:sum+test_gem+1.0.1\n")
     end
 
     it "dependency with multiple versions" do
       param = [build_version(:number => "1.0.1", :dependencies => [
-                               CompactIndex::Dependency.new("foo", "<2.0, >1.0", "ruby", "abc123")
+                               CompactIndex::Dependency.new("foo", "<2.0, >1.0", "ruby", "abc123"),
                              ])]
       expect(CompactIndex.info(param)).to eq("---\n1.0.1 foo:<2.0&>1.0|checksum:sum+test_gem+1.0.1\n")
     end
 
     it "sorts the requirements" do
       param = [build_version(:number => "1.0.1", :dependencies => [
-                               CompactIndex::Dependency.new("foo", ">1.0, <2.0", "ruby", "abc123")
+                               CompactIndex::Dependency.new("foo", ">1.0, <2.0", "ruby", "abc123"),
                              ])]
       expect(CompactIndex.info(param)).to eq("---\n1.0.1 foo:<2.0&>1.0|checksum:sum+test_gem+1.0.1\n")
     end
@@ -85,7 +85,7 @@ describe CompactIndex do
     it "dependencies have platform" do
       param = [build_version(:number => "1.0.1", :dependencies => [
                                CompactIndex::Dependency.new("a", "=1.1", "jruby", "abc123"),
-                               CompactIndex::Dependency.new("b", "=1.2", "darwin-13", "abc123")
+                               CompactIndex::Dependency.new("b", "=1.2", "darwin-13", "abc123"),
                              ])]
       expect(CompactIndex.info(param)).to eq("---\n1.0.1 a:=1.1-jruby,b:=1.2-darwin-13|checksum:sum+test_gem+1.0.1\n")
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "compact_index"

--- a/spec/support/versions.rb
+++ b/spec/support/versions.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 def build_version(args = {})
   name = args.fetch(:name, "test_gem")
   number = args.fetch(:number, "1.0")

--- a/spec/support/versions_file.rb
+++ b/spec/support/versions_file.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 require "compact_index/versions_file"
 

--- a/spec/versions_file_spec.rb
+++ b/spec/versions_file_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "tempfile"
 require "spec_helper"
 require "compact_index/versions_file"

--- a/spec/versions_file_spec.rb
+++ b/spec/versions_file_spec.rb
@@ -41,6 +41,7 @@ describe CompactIndex::VersionsFile do
     end
     let(:versions_file) { versions_file = CompactIndex::VersionsFile.new(file.path) }
 
+    # rubocop:disable Style/IndentHeredoc
     describe "#create" do
       it "writes one line per gem" do
         expected_file_output = <<-EOS

--- a/spec/versions_file_spec.rb
+++ b/spec/versions_file_spec.rb
@@ -35,8 +35,8 @@ describe CompactIndex::VersionsFile do
         CompactIndex::Gem.new("gem5", [build_version(:name => "gem5", :number => "1.0.1")]),
         CompactIndex::Gem.new("gem2", [
                                 build_version(:name => "gem2", :number => "1.0.1"),
-                                build_version(:name => "gem2", :number => "1.0.2", :platform => "arch")
-                              ])
+                                build_version(:name => "gem2", :number => "1.0.2", :platform => "arch"),
+                              ]),
       ]
     end
     let(:versions_file) { versions_file = CompactIndex::VersionsFile.new(file.path) }
@@ -64,7 +64,7 @@ gem5 1.0.1 info+gem5+1.0.1
         versions_file = CompactIndex::VersionsFile.new(file.path)
         gems = [
           CompactIndex::Gem.new("gem_b", [build_version]),
-          CompactIndex::Gem.new("gem_a", [build_version])
+          CompactIndex::Gem.new("gem_a", [build_version]),
         ]
         versions_file.create(gems)
         expect(file.open.read).to eq(<<-EOS)
@@ -85,8 +85,8 @@ gem_b 1.0 info+test_gem+1.0
               build_version(:number => "2.2"),
               build_version(:number => "1.1.1"),
               build_version(:number => "1.1.1"),
-              build_version(:number => "2.1.2")
-            ])
+              build_version(:number => "2.1.2"),
+            ]),
         ]
         versions_file.create(gems)
         expect(file.open.read).to include("test 1.3.0,2.2,1.1.1,1.1.1,2.1.2 info+test_gem+2.1.2")
@@ -125,8 +125,8 @@ gem_b 1.0 info+test_gem+1.0
       extra_gems = [
         CompactIndex::Gem.new("gem3", [
                                 build_version(:name => "gem3", :number => "1.0.1"),
-                                build_version(:name => "gem3", :number => "1.0.2", :platform => "arch")
-                              ])
+                                build_version(:name => "gem3", :number => "1.0.2", :platform => "arch"),
+                              ]),
       ]
       expect(
         versions_file.contents(extra_gems)
@@ -138,8 +138,8 @@ gem_b 1.0 info+test_gem+1.0
     it "has info_checksum" do
       gems = [
         CompactIndex::Gem.new("test", [
-                                build_version(:info_checksum => "testsum", :number => "1.0")
-                              ])
+                                build_version(:info_checksum => "testsum", :number => "1.0"),
+                              ]),
       ]
       expect(
         versions_file.contents(gems)
@@ -151,8 +151,8 @@ gem_b 1.0 info+test_gem+1.0
     it "has the platform" do
       gems = [
         CompactIndex::Gem.new("test", [
-                                build_version(:name => "test", :number => "1.0", :platform => "jruby")
-                              ])
+                                build_version(:name => "test", :number => "1.0", :platform => "jruby"),
+                              ]),
       ]
       expect(
         versions_file.contents(gems)
@@ -168,9 +168,9 @@ gem_b 1.0 info+test_gem+1.0
             [
               build_version(:number => "1.0", :platform => "ruby", :dependencies =>
                 [
-                  CompactIndex::Dependency.new("foo", "=1.0.1", "ruby", "abc123")
-                ])
-            ])
+                  CompactIndex::Dependency.new("foo", "=1.0.1", "ruby", "abc123"),
+                ]),
+            ]),
         ]
       end
 


### PR DESCRIPTION
Follow up to bundler/compact_index#21.

This PR fixes the following error and subsequent warning by RuboCop.

```sh
% bundle exec rake
Running RuboCop...
Error: obsolete parameter AlignWith (for Lint/EndAlignment) found in /Users/koic/src/github.com/bundler/compact_index/.rubocop-bundler.yml
`AlignWith` has been renamed to `EnforcedStyleAlignWith`
RuboCop failed!
```

First, I fixed it using autocorrect (`rubocop -a`) . Next, `db/migrations/*.rb` and `spec/**/*.rb` were excluded because they can't avoid warning by `Metrics/BlockLength`. Finally, I applied `rubocop:disable` to the source codes.
